### PR TITLE
Correctie controle aanwezigheid kolom in datablok

### DIFF
--- a/Gef2Open.py
+++ b/Gef2Open.py
@@ -137,7 +137,7 @@ def get_data(i_Kol, iRij):
 	headerdict=ast.literal_eval(pickle.load(fp))
 	if 'datablok' in headerdict:
 		if iRij in headerdict['datablok']:
-			if i_Kol-1 in headerdict['datablok'][iRij]:
+			if len(headerdict['datablok'][iRij]) >= i_Kol - 1:
 				out=headerdict['datablok'][iRij][i_Kol-1]
 			else:
 				err='MissingKol'


### PR DESCRIPTION
Gef2Open.get_data(2, 3) gaf een foutmelding om dat de waarde 3 niet in
de data dictionary aanwezig was.